### PR TITLE
:sparkles: Add model migration according to draft ERD. This closes #2

### DIFF
--- a/app/Media.php
+++ b/app/Media.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Media extends Model
+{
+    //
+}

--- a/app/Movie.php
+++ b/app/Movie.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Movie extends Model
+{
+    //
+}

--- a/app/Person.php
+++ b/app/Person.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Person extends Model
+{
+    //
+}

--- a/app/Series.php
+++ b/app/Series.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Series extends Model
+{
+    //
+}

--- a/app/Staff.php
+++ b/app/Staff.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Staff extends Model
+{
+    //
+}

--- a/database/migrations/2019_01_16_123100_create_people_table.php
+++ b/database/migrations/2019_01_16_123100_create_people_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('people', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('people');
+    }
+}

--- a/database/migrations/2019_01_16_123101_create_movies_table.php
+++ b/database/migrations/2019_01_16_123101_create_movies_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMoviesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('movies', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('movies');
+    }
+}

--- a/database/migrations/2019_01_16_123533_create_staff_table.php
+++ b/database/migrations/2019_01_16_123533_create_staff_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateStaffTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('staff', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('movie_id')->unsigned();
+            $table->integer('person_id')->unsigned();
+            $table->string('job');
+            $table->timestamps();
+            
+            $table->foreign('movie_id')->references('id')->on('movies');
+            $table->foreign('person_id')->references('id')->on('people');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('staff');
+    }
+}

--- a/database/migrations/2019_01_16_124928_create_series_table.php
+++ b/database/migrations/2019_01_16_124928_create_series_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSeriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('series', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('total_seasons');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('series');
+    }
+}

--- a/database/migrations/2019_01_16_125000_create_media_table.php
+++ b/database/migrations/2019_01_16_125000_create_media_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMediaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('movie_id')->unsigned();
+            $table->integer('series_id')->unsigned();
+            $table->string('title');
+            $table->enum('type', ['series', 'movie']);
+            $table->year('year');
+            $table->string('country');
+            $table->string('imdb_id');
+            $table->string('genre');
+            $table->string('runtime');
+            
+            $table->timestamps();
+
+            $table->foreign('series_id')->references('id')->on('series');
+            $table->foreign('movie_id')->references('id')->on('movies');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('media');
+    }
+}

--- a/database/migrations/2019_01_16_125001_create_actors_table.php
+++ b/database/migrations/2019_01_16_125001_create_actors_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateActorsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('actors', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('movie_id')->unsigned();
+            $table->integer('person_id')->unsigned();
+            $table->string('role');
+            $table->timestamps();
+
+            $table->foreign('movie_id')->references('id')->on('movies');
+            $table->foreign('person_id')->references('id')->on('people');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('actors');
+    }
+}


### PR DESCRIPTION
-Timestamps for migrations dictates the order at which they run
and these are order dependant.
-Constraints for foreign keys must be the same for both tables